### PR TITLE
Added a note about the June 2021 node provider remuneration proposals

### DIFF
--- a/proposals/node_provider_rewards/20210611.md
+++ b/proposals/node_provider_rewards/20210611.md
@@ -1,4 +1,6 @@
-Proposals to distribute the following rewards to the node providers:
+Proposals to distribute the following rewards to the node providers
+(**Note**: The rewards paid out this month cover the time span from the first
+nodes becoming available until June 2021):
 
 | Node provider principal ID | Recipient account | Amount |
 | -------------------------- | ----------------- | ------ |
@@ -75,4 +77,3 @@ Proposals to distribute the following rewards to the node providers:
 | `6mifr-stcqy-w5pzr-qpijh-jopft-p6jl3-n2sww-jhmzg-uzknn-hte4m-pae` | `18cbd29c4ed82cc94dc958810fb421276dd75785ba08558cdf3ba467d9e6dcb6` | 117.2768 ICP |
 | `q22bo-3uyqa-jvtpt-gapjk-pseor-esx4a-zyb74-vzea4-o7nx2-tafgq-hae` | `19d4f5c8f161ebcca6f452a6c7c9d5c32071e106da01e565c7fc4f712c30eecb` | 893.1893 ICP |
 | `ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae` | `9c962ce1902cb14aa6875cd46c2ed32ae3d2d5b2fc5ffc7ee01e698fb0ffc296` | 13094.8274 ICP |
-


### PR DESCRIPTION
The rewards paid out this month cover the whole time span from the first nodes coming online until 2021, which explains why the rewards are substantial.
A note has been added that makes this clear.