### PR TITLE
Node provider remuneration update

### DIFF
--- a/proposals/node_provider_rewards/20210630.md
+++ b/proposals/node_provider_rewards/20210630.md
@@ -1,4 +1,4 @@
-Proposal to distribute the following rewards to the node providers
+Proposals to distribute the following rewards to the node providers
 (**Note**: The rewards paid out this month cover the time span from the first
 nodes becoming available until June 2021):
 

--- a/proposals/node_provider_rewards/20210714.md
+++ b/proposals/node_provider_rewards/20210714.md
@@ -1,4 +1,5 @@
-Proposal to distribute the following rewards to the node providers:
+Proposal to distribute the following rewards to the node providers
+(**Note**: The list also contains the delayed initial payouts from June 2021):
 
 | Node provider principal ID | Recipient account | Amount |
 | -------------------------- | ----------------- | ------ |
@@ -103,4 +104,3 @@ Proposal to distribute the following rewards to the node providers:
 | `x3zyd-pkcbf-5n3w2-n7uov-2qrbt-d3kfn-ojdd7-pxog5-vpqnt-6lex5-fqe` | `18614cba935a756a144531018cd899b11c7904d2a58fcde612e96b0d2ca6f984` | 206.4057 ICP |
 | `75hbn-kovfa-2qd3g-wccis-hlgzc-ywuet-i4iiw-dwa3w-bswhf-ucjp4-rqe` | `2598cc7785ae5dfd73ddaf25440b1d447803c297c7cbdd36bf406cee6a434537` | 206.4068 ICP |
 | `i6sxi-fks25-viets-mboa7-3i23b-qeocf-e57qj-ar6vy-2mchu-xb5vp-aqe` | `4046f63117597224eb87089079924f4113c9b24e475389ec721cb4118c2a399a` | 206.5322 ICP |
-


### PR DESCRIPTION
Fixed a typo and added a note that the July 2021 reward payouts contain the remaining initial payouts that could not be completed in June 2021.