### PR TITLE
Fixed a wrong ICP amount

### DIFF
--- a/proposals/node_provider_rewards/20210714.md
+++ b/proposals/node_provider_rewards/20210714.md
@@ -91,7 +91,7 @@ Proposal to distribute the following rewards to the node providers
 | `3siog-htc6j-ed3wz-sguhu-2objz-g5qct-npoma-t3wwt-bd6wy-chwsi-4ae` | `eee3ff7dfa7b73adab48ba3e6c55a39fbce02cf09c49037114e62d1d8ccf0994` | 229.9792 ICP |
 | `ob633-g55bt-y6pu5-5iby6-jmcvi-oylqs-q6ahw-cvecq-5ckeh-m4wws-nae` | `f94d8363bc9b82923bf06b3c2411d778282bae07e71a79cf1d7bc73d7d2a8965` | 265.3356 ICP |
 | `l2kri-jarwr-7whc4-pjdpn-n6hlb-45ltr-l6ghm-twttl-pcsvt-rynko-dqe` | `442625eafcc570d32a840d4adae53f5f268cf5bd867998de5785d6ff3f065282` | 226.7685 ICP |
-| `owkm4-f44nz-g23do-jicwx-zzyhm-p66ru-lbeua-fwuly-gnmgc-dx7e2-gqe` | `9434c256cd64a3887bc704c033e1c0477d6ff554461129e9c28f92b628fa96a9` | 67.7528 ICP |
+| `owkm4-f44nz-g23do-jicwx-zzyhm-p66ru-lbeua-fwuly-gnmgc-dx7e2-gqe` | `9434c256cd64a3887bc704c033e1c0477d6ff554461129e9c28f92b628fa96a9` | 302.5849 ICP |
 | `q22bo-3uyqa-jvtpt-gapjk-pseor-esx4a-zyb74-vzea4-o7nx2-tafgq-hae` | `19d4f5c8f161ebcca6f452a6c7c9d5c32071e106da01e565c7fc4f712c30eecb` | 227.2431 ICP |
 | `waj5k-wlyvv-jbj4n-vxwjm-dmkyg-uw2nl-ggojp-34kln-wgx3n-d7xih-5qe` | `c1f25e22d91fd462d9e114c8cb8ea0230891fe90e2928e77a164190e4f043af6` | 226.4769 ICP |
 | `2wxxr-qwylo-n7dhz-6co6m-iektd-vl7dn-ocvyc-xazaf-hbfxq-66spe-aae` | `36a2829cd18e3a57c3dc837e54c399d5cbf92fa416ea4cfe9cb8e8e9d7e23f77` | 226.451 ICP |


### PR DESCRIPTION
One ICP amount for the node provider remuneration in July 2021 was wrong.
This PR fixes it.