### PR TITLE
Revert changes to the proposal release notes

### DIFF
--- a/proposals/network_canister_management/NNS_Dapp_20210728T1505Z.md
+++ b/proposals/network_canister_management/NNS_Dapp_20210728T1505Z.md
@@ -1,26 +1,26 @@
-# NNS Dapp: Security fixes, UI enhancements, improved hardware wallet support.
+# Upgrade NNS Dapp canister to commit 51f34a1f53c155deeb73efb878369c42f428b078.
 
-## Summary
+Wasm hash: 9705ca6038d6b70e3436c7e45d0a258975d9be00c2b4dbb18dcc28c215496eef (https://github.com/dfinity/nns-dapp/runs/3182600096)
 
-This updates the NNS dapp to commit `a4116cbfefeaf1887a6fb0f6515b979d8f279a9e`, which contains some minor security fixes, UI changes, and work to support the future hardware wallets.
-
-## Wasm Hash
-
-fef3b875094e73f780821af77f76054826d8e6a058d4a58fa0b29c80082acde9 (https://github.com/dfinity/nns-dapp/runs/3371469917?check_suite_focus=true)
-
-## Changes:
+Changes:
 
 ```
-git log --oneline --first-parent git log --oneline --first-parent 51f34a1f53c155deeb73efb878369c42f428b078..a4116cbfefeaf1887a6fb0f6515b979d8f279a9e
-a4116cb EXC-424: Add support for staking via ledger hardware wallet. (#156)
-799693c Update flutter version in docker (#157)
-92126c7 EXC-424: Add CLI for Ledger HW wallet. (#154)
-ca4b4a3 Update testnet identity service url (#155)
-dec8ccd EXC-416: Upgrade dependencies (#152)
-a27314f Reduce minimum hotkey length since canisters can be hotkeys (#150)
-aded092 EXC-415: Delete buggy 'remove_hardware_wallet' endpoint (#151)
-962577e EXC-414: Migrate remove hotkeys, increase dissolve delay, start/stop dissolving to PB. (#149)
-9b821d7 Update governance canister candid file (#146)
-816913c staking neuron for hardware wallet  (#147)
-f6c5c92 EXC-405: Use protobuf endpoint when adding hot keys. (#145)
+git log --oneline --first-parent 97910b5714353e04888755c0838a9ddd037b45dc..51f34a1f53c155deeb73efb878369c42f428b078
+
+51f34a1 Fix voting power display on 'Increase Dissolve Delay' widget (#144)
+7527ade Rename 'aging bonus' to 'age bonus' (#143)
+b9aedd6 Show Voting power only if dissolve delay is greater than 6 months. (#142)
+3dacc01 Neuron source account (#141)
+47c8a7b Check balance is greater than transaction fee before refunding (#140)
+6174ce9 Voting power information (#139)
+2993f4d EXC-391: Support staking via the 'send' transaction (#138)
+d6389f5 removed textScaleFactor from widgets and replaced with font sizes. (#137)
+cd755b8 EXC-390: Allow principal of main account to fetch the tx status of a HW account. (#136)
+360b6f4 Fixed size given for font size of overlay widget (#135)
+d5766e6 Made Text Sizes for widgets of neuron page to be proportioned to the  same size throughout the page (#134)
+845f7b3 Confirmation box now shown before unlocking neuron (#133)
+3ed4c12 Fix page formats for mobile (#132)
+c71be3d chore: Update candid files. (#131)
+e16ab78 Add hotkey new (#130)
+c79832e EXC-363: Replace lazy_static with thread_local (#129)
 ```


### PR DESCRIPTION
When we recently released the dapp we mistakingly changed the previous release notes file instead of adding a new one. This fixes that.